### PR TITLE
update license also on main branch

### DIFF
--- a/pack/eddy4R.turb/DESCRIPTION
+++ b/pack/eddy4R.turb/DESCRIPTION
@@ -19,6 +19,6 @@ Imports:
     plyr (>= 1.8.4)
 Suggests:
     DataCombine (>= 0.2.21),
-License: Terms of use of the NEON FIU algorithm repository dated 2015-01-16
+License: GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
 LazyData: true
 RoxygenNote: 7.2.3


### PR DESCRIPTION
@ddurden I think this might be a good opportunity to update the eddy4R.turb license to AGPL3 also on the master (main) branch (already the case in NEONScience/deve), to avoid future merge conflicts with deve (which I just encountered following our fork -> branches update recipe).